### PR TITLE
Update function-csharp-ai-textsummarize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ This command will clone the code to your current folder and prompt you for the f
 
 - `Environment Name`: This will be used as a prefix for the resource group that will be created to hold all Azure resources. This name should be unique within your Azure subscription.
 
-3. Run the following command to build a deployable copy of your application, provision the template's infrastructure to Azure and also deploy the applciation code to those newly provisioned resources.
+3. Run the following command to package a deployable copy of your application, provision the template's infrastructure to Azure and also deploy the application code to those newly provisioned resources.
 
 ```bash
 azd up
@@ -108,4 +108,4 @@ This command will prompt you for the following information:
 - `Azure Location`: The Azure location where your resources will be deployed.
 - `Azure Subscription`: The Azure Subscription where your resources will be deployed.
 
-> NOTE: This may take a while to complete as it executes three commands: `azd package` (builds a deployable copy of your application),`azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it packages, provisions and deploys your application.
+> NOTE: This may take a while to complete as it executes three commands: `azd package` (packages a deployable copy of your application),`azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it packages, provisions and deploys your application.

--- a/README.md
+++ b/README.md
@@ -87,8 +87,25 @@ You will see AI analysis happen in the Terminal standard out.  The analysis will
 
 The easiest way to deploy this app is using the [Azure Dev CLI aka AZD](https://aka.ms/azd).  If you open this repo in GitHub CodeSpaces the AZD tooling is already preinstalled.
 
-To provision and deploy:
-1) Open a new terminal and do the following from root folder:
+1. Open a terminal, create a new empty folder, and change into it.
+2. Run the following command to initialize the project. 
+
+```bash
+azd init --template https://github.com/Azure-Samples/function-csharp-ai-textsummarize
+``` 
+
+This command will clone the code to your current folder and prompt you for the following information:
+
+- `Environment Name`: This will be used as a prefix for the resource group that will be created to hold all Azure resources. This name should be unique within your Azure subscription.
+
+3. Run the following command to build a deployable copy of your application, provision the template's infrastructure to Azure and also deploy the applciation code to those newly provisioned resources.
+
 ```bash
 azd up
 ```
+
+This command will prompt you for the following information:
+- `Azure Location`: The Azure location where your resources will be deployed.
+- `Azure Subscription`: The Azure Subscription where your resources will be deployed.
+
+> NOTE: This may take a while to complete as it executes three commands: `azd package` (builds a deployable copy of your application),`azd provision` (provisions Azure resources), and `azd deploy` (deploys application code). You will see a progress indicator as it packages, provisions and deploys your application.


### PR DESCRIPTION
Update function-csharp-ai-textsummarize README to use `azd init` and `azd up` instead of `azd up --template` according to https://github.com/Azure/azure-dev/issues/1769.

@jongio, @rajeshkamal5050 for notification.